### PR TITLE
remove vat number following de-registration

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,7 +19,6 @@
           </ul>
           <ul class="numbers">
             <li>Registered in England no. 06358948</li>
-            <li>VAT reg. no. <span>GB</span>917723315</li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
De-registered for VAT from 31/01/2021